### PR TITLE
Fix build add missing include

### DIFF
--- a/src/elite.h
+++ b/src/elite.h
@@ -17,6 +17,7 @@ THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "rfw_random.h"
 #include "spgconfig.h"
 #include <cstdio>
+#include <limits>
 
 class SolutionPool {
 private:


### PR DESCRIPTION
The compilation on linux failed because of a missing include. This PR fixes this.